### PR TITLE
Add generate random name button next to any name field

### DIFF
--- a/src/components/RFC1035Input.tsx
+++ b/src/components/RFC1035Input.tsx
@@ -1,6 +1,15 @@
-import { Link, Stack, TextField, Typography } from "@mui/material";
+import {
+  IconButton,
+  InputAdornment,
+  Link,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { faker } from "@faker-js/faker";
+import Iconify from "./Iconify";
 
 export type RFC1035InputProps = {
   label: string;
@@ -13,6 +22,7 @@ export type RFC1035InputProps = {
   setCleaned: (val: string) => void;
   initialValue?: string;
   maxWidth?: string;
+  enableRandomize?: boolean;
 };
 
 export default function RFC1035Input({
@@ -26,6 +36,7 @@ export default function RFC1035Input({
   setCleaned,
   initialValue = "",
   maxWidth = "100%",
+  enableRandomize = false,
 }: RFC1035InputProps) {
   const [value, setValue] = useState("");
   const { t } = useTranslation();
@@ -50,6 +61,14 @@ export default function RFC1035Input({
     val = val.replace(/^-|-$/g, "");
 
     setCleaned(val);
+  };
+
+  const randomizeName = () => {
+    const newRandomName = faker.word
+      .words(3)
+      .replace(/[^a-z0-9]|\s+|\r?\n|\r/gim, "-");
+    setValue(newRandomName);
+    clean(newRandomName);
   };
 
   return (
@@ -78,6 +97,15 @@ export default function RFC1035Input({
         onChange={(e) => {
           setValue(e.target.value);
           clean(e.target.value);
+        }}
+        InputProps={{
+          endAdornment: enableRandomize ? (
+            <InputAdornment position="end">
+              <IconButton onClick={randomizeName} size="large">
+                <Iconify icon="mdi:dice-3-outline" />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
         }}
       />
       {cleaned && (

--- a/src/components/RFC1035Input.tsx
+++ b/src/components/RFC1035Input.tsx
@@ -100,7 +100,7 @@ export default function RFC1035Input({
         InputProps={{
           endAdornment: enableRandomize ? (
             <InputAdornment position="end">
-              <RandomizeButton onClick={randomizeName} />
+              <RandomizeButton onClick={randomizeName} size="large" />
             </InputAdornment>
           ) : null,
         }}

--- a/src/components/RFC1035Input.tsx
+++ b/src/components/RFC1035Input.tsx
@@ -1,5 +1,4 @@
 import {
-  IconButton,
   InputAdornment,
   Link,
   Stack,
@@ -9,7 +8,7 @@ import {
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { faker } from "@faker-js/faker";
-import Iconify from "./Iconify";
+import RandomizeButton from "./RandomizeButton";
 
 export type RFC1035InputProps = {
   label: string;
@@ -101,9 +100,7 @@ export default function RFC1035Input({
         InputProps={{
           endAdornment: enableRandomize ? (
             <InputAdornment position="end">
-              <IconButton onClick={randomizeName} size="large">
-                <Iconify icon="mdi:dice-3-outline" />
-              </IconButton>
+              <RandomizeButton onClick={randomizeName} />
             </InputAdornment>
           ) : null,
         }}

--- a/src/components/RandomizeButton.tsx
+++ b/src/components/RandomizeButton.tsx
@@ -1,0 +1,40 @@
+import { IconButton, IconButtonProps } from "@mui/material";
+import Iconify from "./Iconify";
+import { useState } from "react";
+
+export default function RandomizeButton({ onClick, size }: IconButtonProps) {
+  const [rotateDice, setRotateDice] = useState(false);
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setRotateDice(true);
+    if (onClick) {
+      onClick(e);
+    }
+
+    setTimeout(() => {
+      setRotateDice(false);
+    }, 500);
+  };
+  return (
+    <IconButton
+      onClick={handleClick}
+      size={size}
+      sx={
+        rotateDice
+          ? {
+              animation: "spin 0.5s ease-in-out infinite",
+              "@keyframes spin": {
+                "0%": {
+                  transform: "rotate(180deg)",
+                },
+                "100%": {
+                  transform: "rotate(0deg)",
+                },
+              },
+            }
+          : undefined
+      }
+    >
+      <Iconify icon="mdi:dice-3-outline" />
+    </IconButton>
+  );
+}

--- a/src/pages/create/CreateDeployment.tsx
+++ b/src/pages/create/CreateDeployment.tsx
@@ -157,6 +157,7 @@ export default function CreateDeployment({
             setCleaned={setCleaned}
             initialValue={initialName}
             autofocus={!window.location.pathname.includes("onboarding")}
+            enableRandomize={true}
           />
         </CardContent>
       </Card>

--- a/src/pages/create/CreateVm.tsx
+++ b/src/pages/create/CreateVm.tsx
@@ -223,6 +223,7 @@ export default function CreateVm({
                 setCleaned={setCleaned}
                 initialValue={initialName}
                 autofocus={!window.location.pathname.includes("onboarding")}
+                enableRandomize={true}
               />
 
               {user && (


### PR DESCRIPTION
Added randomize name button to the 'RFC1035Input.tsx' component, it can be enabled by adding the optional parameter 'enableRandomize' and setting it to true. Which I enabled for deployments in 'CreateDeployments.tsx' and for vms in 'CreateVm.tsx'.

It uses faker-js to generate a random name for k8s deployments or vms, with the regex used to generate random names when not running as release.

The icon is the one that was recommended in the issue, mdi:dice-3-outline.

#233 

![image](https://github.com/kthcloud/console/assets/112874974/97acf347-3e72-4210-87b2-78935ed2d056)
![image](https://github.com/kthcloud/console/assets/112874974/a5b28bae-720c-41c0-b602-8f59fea07531)
![Screencast from 2024-05-14 08-29-35](https://github.com/kthcloud/console/assets/112874974/23cc4437-a08b-49da-bac1-14b64f98c5d8)
(gif quality === very many)

