### PR TITLE
Fix specs being set to min if greater than min

### DIFF
--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -48,7 +48,6 @@ export const Specs = ({ resource }: { resource: Resource }) => {
 
   const MAX_CPU_VM = 20;
   const MAX_RAM_VM = 20;
-  
 
   const [maxCpu, setMaxCpu] = useState<number>(
     resource.type === "vm" ? MAX_CPU_VM : MAX_CPU_DEPLOYMENT
@@ -82,7 +81,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
     }
   };
 
-  const [cpu, setCpu] = useState<number>(getInitialCpu()); 
+  const [cpu, setCpu] = useState<number>(getInitialCpu());
   const [ram, setRam] = useState<number>(getInitialRam());
   const [replicas, setReplicas] = useState<number>(0);
 


### PR DESCRIPTION
Fixes the issue described here #278 

I am setting the initial state of the max values of the resoures specs to the max value of 20 instead of initally setting it to the min value and then updating it to the max value in a useEffect call later in the code.

I also made it so that the specs get updated if they change on the resource, unless editing is set to true.

![image](https://github.com/kthcloud/console/assets/112874974/16a0ff2f-f12e-4d60-81f2-f5f594ae2d70)


Let me know if I should change anything :)