### PR TITLE
Show replica status, closes #272

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -523,6 +523,7 @@
         "ready": "Ready",
         "occupied": "Occupied",
         "unavailable": "Unavailable",
-        "desired": "Desired"
+        "desired": "Desired",
+        "replica-status": "Replica status"
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -522,6 +522,7 @@
         "per-replica": "per replica",
         "ready": "Ready",
         "occupied": "Occupied",
-        "unavailable": "Unavailable"
+        "unavailable": "Unavailable",
+        "wanted": "Wanted"
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -519,6 +519,9 @@
         "gpu-zone-subheader": "This GPU is available in the following zones, choose the same zone as your desired VM destination.",
         "select-vm-gpu": "Select a VM to attach this GPU to.",
         "replica-quota": "Increasing replicas will multiply the CPU and RAM usage of this deployment.",
-        "per-replica": "per replica"
+        "per-replica": "per replica",
+        "ready": "Ready",
+        "occupied": "Occupied",
+        "unavailable": "Unavailable"
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -523,6 +523,6 @@
         "ready": "Ready",
         "occupied": "Occupied",
         "unavailable": "Unavailable",
-        "wanted": "Wanted"
+        "desired": "Desired"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -522,6 +522,7 @@
         "ready": "Redo",
         "occupied": "Upptagna",
         "unavailable": "Otillgängliga",
-        "desired": "Önskade"
+        "desired": "Önskade",
+        "replica-status": "Status på kopior"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -518,6 +518,9 @@
         "gpu-zone-subheader": "Det här grafikkortet finns i flera zoner. Välj samma zon som virtuella maskinen du vill installera grafikkortet på.",
         "select-vm-gpu": "Välj en virtuell maskin att installera grafikkortet på.",
         "replica-quota": "Ökning av kopior kommer att multiplicera CPU- och RAM-användningen för denna deployment.",
-        "per-replica": "per kopia"
+        "per-replica": "per kopia",
+        "ready": "Redo",
+        "occupied": "Upptagna",
+        "unavailable": "Otillgängliga"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -521,6 +521,7 @@
         "per-replica": "per kopia",
         "ready": "Redo",
         "occupied": "Upptagna",
-        "unavailable": "Otillgängliga"
+        "unavailable": "Otillgängliga",
+        "wanted": "Önskade"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -522,6 +522,6 @@
         "ready": "Redo",
         "occupied": "Upptagna",
         "unavailable": "Otillgängliga",
-        "wanted": "Önskade"
+        "desired": "Önskade"
     }
 }

--- a/src/pages/edit/Edit.tsx
+++ b/src/pages/edit/Edit.tsx
@@ -318,7 +318,7 @@ export function Edit() {
 
                 {resource.type === "deployment" && (
                   <>
-                    {resource.replicas > 1 && ( // Todo: change to 1 b4 PR
+                    {resource.replicas > 1 && (
                       <ReplicaStatus deployment={resource as Deployment} />
                     )}
                     <DeploymentCommands deployment={resource as Deployment} />

--- a/src/pages/edit/Edit.tsx
+++ b/src/pages/edit/Edit.tsx
@@ -46,6 +46,7 @@ import { Job, Resource, Deployment, Vm } from "../../types";
 import { Volume } from "@kthcloud/go-deploy-types/types/v1/body";
 import { AlertList } from "../../components/AlertList";
 import { Specs } from "./Specs";
+import { ReplicaStatus } from "./deployments/ReplicaStatus";
 
 export function Edit() {
   const { t } = useTranslation();
@@ -316,7 +317,12 @@ export function Edit() {
                 <div style={{ flexGrow: "1" }} />
 
                 {resource.type === "deployment" && (
-                  <DeploymentCommands deployment={resource as Deployment} />
+                  <>
+                    {resource.replicas > 0 && (
+                      <ReplicaStatus deployment={resource as Deployment} />
+                    )}
+                    <DeploymentCommands deployment={resource as Deployment} />
+                  </>
                 )}
 
                 {resource.type === "vm" && <VMCommands vm={resource as Vm} />}

--- a/src/pages/edit/Edit.tsx
+++ b/src/pages/edit/Edit.tsx
@@ -318,7 +318,7 @@ export function Edit() {
 
                 {resource.type === "deployment" && (
                   <>
-                    {resource.replicas > 0 && (
+                    {resource.replicas > 0 && ( // Todo: change to 1 b4 PR
                       <ReplicaStatus deployment={resource as Deployment} />
                     )}
                     <DeploymentCommands deployment={resource as Deployment} />

--- a/src/pages/edit/Edit.tsx
+++ b/src/pages/edit/Edit.tsx
@@ -318,7 +318,7 @@ export function Edit() {
 
                 {resource.type === "deployment" && (
                   <>
-                    {resource.replicas > 0 && ( // Todo: change to 1 b4 PR
+                    {resource.replicas > 1 && ( // Todo: change to 1 b4 PR
                       <ReplicaStatus deployment={resource as Deployment} />
                     )}
                     <DeploymentCommands deployment={resource as Deployment} />

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -1,7 +1,13 @@
 import { DeploymentRead } from "@kthcloud/go-deploy-types/types/v1/body";
 import { IconButton, Stack, Theme, useTheme } from "@mui/material";
 import Iconify from "../../../components/Iconify";
-import { Dispatch, ReactNode, SetStateAction, useState } from "react";
+import {
+  CSSProperties,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 export interface ReplicaProps {
@@ -19,9 +25,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
   if (deployment.replicaStatus == undefined) return <></>;
   const [expanded, setExpanded] = useState<boolean>(false);
   const theme = useTheme();
-  deployment.replicaStatus.availableReplicas = 3;
-  deployment.replicaStatus.unavailableReplicas = 2;
-  deployment.replicaStatus.desiredReplicas = 7;
+  deployment.replicaStatus.availableReplicas = 3; // Todo: Change b4 PR
   const replicas = [
     ...Array.from(
       { length: deployment.replicaStatus.readyReplicas },
@@ -58,20 +62,10 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
         direction="row"
         flexWrap={"wrap"}
         alignItems={"center"}
-        spacing={deployment.replicas}
+        spacing={3}
         useFlexGap={true}
       >
-        <Stack
-          direction="row"
-          flexWrap={"wrap"}
-          alignItems={"center"}
-          spacing={deployment.replicas}
-          useFlexGap={true}
-          gap={"0.1rem"}
-          width={"6rem"}
-        >
-          <ReplicaDisplay replicas={replicas} theme={theme} />
-        </Stack>
+        <ReplicaDisplay replicas={replicas} theme={theme} />
         <ExpandButton toggle={setExpanded} expanded={expanded} />
       </Stack>
       {expanded && (
@@ -168,7 +162,7 @@ function ReplicaDisplay({
   theme,
 }: {
   replicas: ReplicaStatusEnum[];
-  theme?: Theme;
+  theme: Theme;
 }) {
   const baseStyle = {
     width: "100%",
@@ -179,36 +173,46 @@ function ReplicaDisplay({
   const styles = {
     [ReplicaStatusEnum.UNAVAILABLE]: {
       ...baseStyle,
-      backgroundColor: theme?.palette["error"].main,
+      backgroundColor: theme.palette["error"].main,
     },
     [ReplicaStatusEnum.READY]: {
       ...baseStyle,
-      backgroundColor: theme?.palette["success"].main,
+      backgroundColor: theme.palette["success"].main,
     },
     [ReplicaStatusEnum.OCCUPIED]: {
       ...baseStyle,
-      backgroundColor: theme?.palette["info"].main,
+      backgroundColor: theme.palette["info"].main,
     },
     [ReplicaStatusEnum.WANTED]: {
       ...baseStyle,
-      backgroundColor: theme?.palette.grey[800],
+      backgroundColor: theme.palette.grey[800],
     },
   };
 
+  const style: CSSProperties = {
+    display: "flex",
+    flexDirection: "row",
+    gap: "1%",
+    width: "100%",
+    borderRadius: "0.5rem",
+    overflow: "hidden",
+  };
+
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        gap: "1%",
-        width: "100%",
-        borderRadius: "0.5rem",
-        overflow: "hidden",
-      }}
+    <Stack
+      direction="row"
+      flexWrap={"wrap"}
+      alignItems={"center"}
+      spacing={3}
+      useFlexGap={true}
+      gap={"0.1rem"}
+      width={"6rem"}
     >
-      {replicas.map((replica, index) => (
-        <div key={`${index}`} style={styles[replica]}></div>
-      ))}
-    </div>
+      <div style={style}>
+        {replicas.map((replica, index) => (
+          <div key={`${index}`} style={styles[replica]}></div>
+        ))}
+      </div>
+    </Stack>
   );
 }

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -21,7 +21,7 @@ enum ReplicaStatusEnum {
   READY,
   OCCUPIED,
   UNAVAILABLE,
-  WANTED,
+  DESIRED,
 }
 
 export function ReplicaStatus({ deployment }: ReplicaProps) {
@@ -33,7 +33,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
   const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorElement(event.currentTarget.parentElement);
+    setAnchorElement(event.currentTarget);
     setExpanded(true);
   };
   const handleClose = () => {
@@ -41,7 +41,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     setAnchorElement(null);
   };
 
-  deployment.replicaStatus.availableReplicas = 3; // Todo: Change b4 PR
+  //deployment.replicaStatus.availableReplicas = 3; // Todo: Change b4 PR
   const replicas = [
     ...Array.from(
       { length: deployment.replicaStatus.readyReplicas },
@@ -68,7 +68,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
           (deployment.replicaStatus.availableReplicas +
             deployment.replicaStatus.unavailableReplicas),
       },
-      () => ReplicaStatusEnum.WANTED
+      () => ReplicaStatusEnum.DESIRED
     ),
   ];
 
@@ -77,7 +77,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     deployment.replicaStatus.availableReplicas -
     deployment.replicaStatus.readyReplicas;
   const amountUnavailable = deployment.replicaStatus.unavailableReplicas;
-  const amountWanted =
+  const amountDesired =
     deployment.replicaStatus.desiredReplicas -
     (deployment.replicaStatus.unavailableReplicas +
       deployment.replicaStatus.availableReplicas);
@@ -85,6 +85,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     display: "flex",
     justifyContent: "space-between",
     gap: "1rem",
+    width: "inherit"
   };
   return (
     <div style={{ position: "relative" }}>
@@ -107,9 +108,19 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
           "aria-labelledby": "expand-button",
         }}
         anchorEl={anchorElement}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
         open={expanded}
         onClose={handleClose}
         TransitionComponent={Fade}
+        disableScrollLock={true}
+        sx={{zIndex:1}}
       >
         {amountReady > 0 && (
           <MenuItem sx={menuElementStyle}>
@@ -129,10 +140,10 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
             <span>{amountUnavailable}</span>
           </MenuItem>
         )}
-        {amountWanted > 0 && (
+        {amountDesired > 0 && (
           <MenuItem sx={menuElementStyle}>
-            <span>{t("wanted") + ":"}</span>
-            <span>{amountWanted}</span>
+            <span>{t("desired") + ":"}</span>
+            <span>{amountDesired}</span>
           </MenuItem>
         )}
       </Menu>
@@ -149,13 +160,8 @@ function ExpandReplicaStatusButton({
   onClick,
   expanded,
 }: ExpandReplicaStatusButtonProps) {
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    if (onClick) {
-      onClick(e);
-    }
-  };
   return (
-    <IconButton id={id} onClick={handleClick}>
+    <IconButton id={id} onClick={onClick}>
       <Iconify icon={expanded ? "mdi-chevron-up" : "mdi-chevron-down"} />
     </IconButton>
   );
@@ -187,7 +193,7 @@ function ReplicaDisplay({
       ...baseStyle,
       backgroundColor: theme.palette["info"].main,
     },
-    [ReplicaStatusEnum.WANTED]: {
+    [ReplicaStatusEnum.DESIRED]: {
       ...baseStyle,
       backgroundColor: theme.palette.grey[800],
     },
@@ -196,7 +202,7 @@ function ReplicaDisplay({
   const style: CSSProperties = {
     display: "flex",
     flexDirection: "row",
-    gap: "1%",
+    gap: "max(2px, 1%)",
     width: "100%",
     borderRadius: "0.5rem",
     overflow: "hidden",

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -1,0 +1,202 @@
+import { DeploymentRead } from "@kthcloud/go-deploy-types/types/v1/body";
+import { IconButton, Stack } from "@mui/material";
+import Iconify from "../../../components/Iconify";
+import { Dispatch, ReactNode, SetStateAction, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface ReplicaProps {
+  deployment: DeploymentRead;
+}
+
+export enum ReplicaStatusEnum {
+  READY,
+  OCCUPIED,
+  UNAVAILABLE,
+}
+
+export function ReplicaStatus({ deployment }: ReplicaProps) {
+  if (deployment.replicaStatus == undefined) return <></>;
+  const [expanded, setExpanded] = useState<boolean>(false);
+  deployment.replicaStatus.availableReplicas = 2;
+  deployment.replicaStatus.unavailableReplicas = 2;
+  return (
+    <div style={{ position: "relative" }}>
+      <Stack
+        direction="row"
+        flexWrap={"wrap"}
+        alignItems={"center"}
+        spacing={deployment.replicas}
+        useFlexGap={true}
+        gap={"0.2rem"}
+      >
+        <ReplicaDisplay
+          amount={deployment.replicaStatus.readyReplicas}
+          status={ReplicaStatusEnum.READY}
+          isFirst={true}
+          isLast={
+            deployment.replicaStatus.unavailableReplicas === 0 &&
+            deployment.replicaStatus.availableReplicas -
+              deployment.replicaStatus.readyReplicas ===
+              0
+          }
+          gapInRem={0.2}
+        />
+        <ReplicaDisplay
+          amount={
+            deployment.replicaStatus.availableReplicas -
+            deployment.replicaStatus.readyReplicas
+          }
+          status={ReplicaStatusEnum.OCCUPIED}
+          isFirst={deployment.replicaStatus.readyReplicas === 0}
+          isLast={deployment.replicaStatus.unavailableReplicas === 0}
+          gapInRem={0.2}
+        />
+        <ReplicaDisplay
+          amount={deployment.replicaStatus.unavailableReplicas}
+          status={ReplicaStatusEnum.UNAVAILABLE}
+          isLast={true}
+          isFirst={
+            deployment.replicaStatus.availableReplicas -
+              deployment.replicaStatus.readyReplicas ===
+              0 && deployment.replicaStatus.readyReplicas === 0
+          }
+          gapInRem={0.2}
+        />
+        <ExpandButton toggle={setExpanded} expanded={expanded} />
+      </Stack>
+      {expanded && (
+        <Dropdown>
+          <ReplicaDetails deployment={deployment} />
+        </Dropdown>
+      )}
+    </div>
+  );
+}
+
+function ReplicaDisplay({
+  amount,
+  status,
+  borderRadius = undefined,
+  isFirst = false,
+  isLast = false,
+  gapInRem = 0.5,
+}: {
+  amount: number;
+  status: ReplicaStatusEnum;
+  borderRadius?: string;
+  isLast?: boolean;
+  isFirst?: boolean;
+  gapInRem?: number;
+}) {
+  const baseStyle = {
+    width: `${2/amount}rem`,
+    height: `2rem`,
+    maxWidth: `${(2/amount - amount) - (gapInRem*amount-gapInRem)} rem`,
+    borderRadius: borderRadius,
+    color: "rgba(0, 0, 0, 0)"
+  };
+
+  const styles = {
+    [ReplicaStatusEnum.UNAVAILABLE]: {
+      ...baseStyle,
+      backgroundColor: "red",
+    },
+    [ReplicaStatusEnum.READY]: {
+      ...baseStyle,
+      backgroundColor: "green",
+    },
+    [ReplicaStatusEnum.OCCUPIED]: {
+      ...baseStyle,
+      backgroundColor: "blue",
+    },
+  };
+
+  const firstStyles = {
+    ...styles[status],
+    borderRadius: "0.5rem 0 0 0.5rem",
+  };
+
+  const lastStyles = {
+    ...styles[status],
+    borderRadius: "0 0.5rem 0.5rem 0",
+  };
+
+  return (
+    <>
+      {Array.from({ length: amount }).map((_, index) => (
+        <div
+          key={`${index}`}
+          style={
+            index === amount - 1 && isLast
+              ? lastStyles
+              : index === 0 && isFirst
+                ? firstStyles
+                : styles[status]
+          }
+        >.</div>
+      ))}
+    </>
+  );
+}
+
+function ExpandButton({
+  toggle,
+  expanded,
+}: {
+  toggle: Dispatch<SetStateAction<boolean>>;
+  expanded: boolean;
+}) {
+  return (
+    <IconButton onClick={() => toggle(!expanded)}>
+      <Iconify icon={expanded ? "mdi-chevron-up" : "mdi-chevron-down"} />
+    </IconButton>
+  );
+}
+
+function Dropdown({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "100%",
+        left: 0,
+        width: "100%",
+        backgroundColor: "rgba(0, 0, 0, 0.5",
+        borderRadius: "0.5rem",
+        padding: "0.5rem",
+        zIndex: "1",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ReplicaDetails({ deployment }: { deployment: DeploymentRead }) {
+  if (deployment.replicaStatus == undefined) return <></>;
+  const { t } = useTranslation();
+  const listElementStyle = {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: "1rem",
+  };
+  return (
+    <ul style={{ listStyle: "none" }}>
+      <li style={listElementStyle}>
+        <span>{t("ready") + ":"}</span>
+        <span>{deployment.replicaStatus.readyReplicas}</span>
+      </li>
+      <li style={listElementStyle}>
+        <span>{t("occupied") + ":"}</span>
+        <span>
+          {deployment.replicaStatus.availableReplicas -
+            deployment.replicaStatus.readyReplicas}
+        </span>
+      </li>
+      <li style={listElementStyle}>
+        <span>{t("unavailable") + ":"}</span>
+        <span>{deployment.replicaStatus.unavailableReplicas}</span>
+      </li>
+    </ul>
+  );
+}

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -14,40 +14,44 @@ export enum ReplicaStatusEnum {
   UNAVAILABLE,
   WANTED,
 }
-/*
-TODO: Work on width calculation so it doesnt end up janky
-current borderRadius gets wierd once there are alot, make the border radius on an outside div or element of some sort.
- */
+
 export function ReplicaStatus({ deployment }: ReplicaProps) {
   if (deployment.replicaStatus == undefined) return <></>;
   const [expanded, setExpanded] = useState<boolean>(false);
   const theme = useTheme();
   deployment.replicaStatus.availableReplicas = 3;
-  deployment.replicaStatus.unavailableReplicas = 5;
-  deployment.replicaStatus.desiredReplicas = 10;
-  const replicas = [];
-  for (let i in Array.from({
-    length: deployment.replicaStatus.readyReplicas,
-  })) {
-    replicas.push(ReplicaStatusEnum.READY);
-  }
-  for (let i in Array.from({
-    length:
-      deployment.replicaStatus.availableReplicas -
-      deployment.replicaStatus.readyReplicas,
-  })) {
-    replicas.push(ReplicaStatusEnum.OCCUPIED);
-  }
-  for (let i in Array.from({
-    length: deployment.replicaStatus.unavailableReplicas,
-  })) {
-    replicas.push(ReplicaStatusEnum.UNAVAILABLE);
-  }
-  for (let i in Array.from({
-    length: deployment.replicaStatus.desiredReplicas - replicas.length,
-  })) {
-    replicas.push(ReplicaStatusEnum.WANTED);
-  }
+  deployment.replicaStatus.unavailableReplicas = 2;
+  deployment.replicaStatus.desiredReplicas = 7;
+  const replicas = [
+    ...Array.from(
+      { length: deployment.replicaStatus.readyReplicas },
+      () => ReplicaStatusEnum.READY
+    ),
+    ...Array.from(
+      {
+        length:
+          deployment.replicaStatus.availableReplicas -
+          deployment.replicaStatus.readyReplicas,
+      },
+      () => ReplicaStatusEnum.OCCUPIED
+    ),
+    ...Array.from(
+      {
+        length: deployment.replicaStatus.unavailableReplicas,
+      },
+      () => ReplicaStatusEnum.UNAVAILABLE
+    ),
+    ...Array.from(
+      {
+        length:
+          deployment.replicaStatus.desiredReplicas -
+          (deployment.replicaStatus.availableReplicas +
+            deployment.replicaStatus.unavailableReplicas),
+      },
+      () => ReplicaStatusEnum.WANTED
+    ),
+  ];
+
   return (
     <div style={{ position: "relative" }}>
       <Stack
@@ -120,31 +124,41 @@ function ReplicaDetails({ deployment }: { deployment: DeploymentRead }) {
     justifyContent: "space-between",
     gap: "1rem",
   };
+  const amountReady = deployment.replicaStatus.readyReplicas;
+  const amountOccupied =
+    deployment.replicaStatus.availableReplicas -
+    deployment.replicaStatus.readyReplicas;
+  const amountUnavailable = deployment.replicaStatus.unavailableReplicas;
+  const amountWanted =
+    deployment.replicaStatus.desiredReplicas -
+    (deployment.replicaStatus.unavailableReplicas +
+      deployment.replicaStatus.availableReplicas);
   return (
     <ul style={{ listStyle: "none" }}>
-      <li style={listElementStyle}>
-        <span>{t("ready") + ":"}</span>
-        <span>{deployment.replicaStatus.readyReplicas}</span>
-      </li>
-      <li style={listElementStyle}>
-        <span>{t("occupied") + ":"}</span>
-        <span>
-          {deployment.replicaStatus.availableReplicas -
-            deployment.replicaStatus.readyReplicas}
-        </span>
-      </li>
-      <li style={listElementStyle}>
-        <span>{t("unavailable") + ":"}</span>
-        <span>{deployment.replicaStatus.unavailableReplicas}</span>
-      </li>
-      <li style={listElementStyle}>
-        <span>{t("wanted") + ":"}</span>
-        <span>
-          {deployment.replicaStatus.desiredReplicas -
-            (deployment.replicaStatus.unavailableReplicas +
-              deployment.replicaStatus.availableReplicas)}
-        </span>
-      </li>
+      {amountReady > 0 && (
+        <li style={listElementStyle}>
+          <span>{t("ready") + ":"}</span>
+          <span>{amountReady}</span>
+        </li>
+      )}
+      {amountOccupied > 0 && (
+        <li style={listElementStyle}>
+          <span>{t("occupied") + ":"}</span>
+          <span>{amountOccupied}</span>
+        </li>
+      )}
+      {amountUnavailable > 0 && (
+        <li style={listElementStyle}>
+          <span>{t("unavailable") + ":"}</span>
+          <span>{amountUnavailable}</span>
+        </li>
+      )}
+      {amountWanted > 0 && (
+        <li style={listElementStyle}>
+          <span>{t("wanted") + ":"}</span>
+          <span>{amountWanted}</span>
+        </li>
+      )}
     </ul>
   );
 }

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -4,15 +4,14 @@ import {
   IconButton,
   IconButtonProps,
   Menu,
-  MenuItem,
   Stack,
   Theme,
+  Typography,
   useTheme,
 } from "@mui/material";
 import Iconify from "../../../components/Iconify";
 import { CSSProperties, useState } from "react";
 import { useTranslation } from "react-i18next";
-
 export interface ReplicaProps {
   deployment: DeploymentRead;
 }
@@ -41,36 +40,6 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     setAnchorElement(null);
   };
 
-  const replicas = [
-    ...Array.from(
-      { length: deployment.replicaStatus.readyReplicas },
-      () => ReplicaStatusEnum.READY
-    ),
-    ...Array.from(
-      {
-        length:
-          deployment.replicaStatus.availableReplicas -
-          deployment.replicaStatus.readyReplicas,
-      },
-      () => ReplicaStatusEnum.OCCUPIED
-    ),
-    ...Array.from(
-      {
-        length: deployment.replicaStatus.unavailableReplicas,
-      },
-      () => ReplicaStatusEnum.UNAVAILABLE
-    ),
-    ...Array.from(
-      {
-        length:
-          deployment.replicaStatus.desiredReplicas -
-          (deployment.replicaStatus.availableReplicas +
-            deployment.replicaStatus.unavailableReplicas),
-      },
-      () => ReplicaStatusEnum.DESIRED
-    ),
-  ];
-
   const amountReady = deployment.replicaStatus.readyReplicas;
   const amountOccupied =
     deployment.replicaStatus.availableReplicas -
@@ -80,11 +49,35 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     deployment.replicaStatus.desiredReplicas -
     (deployment.replicaStatus.unavailableReplicas +
       deployment.replicaStatus.availableReplicas);
+
+  const replicas = [
+    ...Array.from({ length: amountReady }, () => ReplicaStatusEnum.READY),
+    ...Array.from(
+      {
+        length: amountOccupied,
+      },
+      () => ReplicaStatusEnum.OCCUPIED
+    ),
+    ...Array.from(
+      {
+        length: amountUnavailable,
+      },
+      () => ReplicaStatusEnum.UNAVAILABLE
+    ),
+    ...Array.from(
+      {
+        length: amountDesired,
+      },
+      () => ReplicaStatusEnum.DESIRED
+    ),
+  ];
+
   const menuElementStyle = {
     display: "flex",
     justifyContent: "space-between",
     gap: "1rem",
     width: "inherit",
+    padding: "0 0.7rem 0 0.7rem",
   };
   return (
     <div style={{ position: "relative" }}>
@@ -92,7 +85,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
         direction="row"
         flexWrap={"wrap"}
         alignItems={"center"}
-        spacing={3}
+        spacing={1}
         useFlexGap={true}
       >
         <ReplicaDisplay replicas={replicas} theme={theme} />
@@ -121,29 +114,39 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
         disableScrollLock={true}
         sx={{ zIndex: 1 }}
       >
+        <Typography
+          sx={{
+            ...menuElementStyle,
+            borderBottom: `1px dashed ${theme.palette.text.primary}`,
+            paddingBottom: "0.2rem",
+            marginBottom: "0.5rem",
+          }}
+        >
+          {t("replica-status")}
+        </Typography>
         {amountReady > 0 && (
-          <MenuItem sx={menuElementStyle}>
+          <Typography style={menuElementStyle}>
             <span>{t("ready") + ":"}</span>
             <span>{amountReady}</span>
-          </MenuItem>
+          </Typography>
         )}
         {amountOccupied > 0 && (
-          <MenuItem sx={menuElementStyle}>
+          <Typography sx={menuElementStyle}>
             <span>{t("occupied") + ":"}</span>
             <span>{amountOccupied}</span>
-          </MenuItem>
+          </Typography>
         )}
         {amountUnavailable > 0 && (
-          <MenuItem sx={menuElementStyle}>
+          <Typography sx={menuElementStyle}>
             <span>{t("unavailable") + ":"}</span>
             <span>{amountUnavailable}</span>
-          </MenuItem>
+          </Typography>
         )}
         {amountDesired > 0 && (
-          <MenuItem sx={menuElementStyle}>
+          <Typography sx={menuElementStyle}>
             <span>{t("desired") + ":"}</span>
             <span>{amountDesired}</span>
-          </MenuItem>
+          </Typography>
         )}
       </Menu>
     </div>
@@ -160,7 +163,7 @@ function ExpandReplicaStatusButton({
   expanded,
 }: ExpandReplicaStatusButtonProps) {
   return (
-    <IconButton id={id} onClick={onClick}>
+    <IconButton id={id} onClick={onClick} size="small">
       <Iconify icon={expanded ? "mdi-chevron-up" : "mdi-chevron-down"} />
     </IconButton>
   );
@@ -201,7 +204,7 @@ function ReplicaDisplay({
   const style: CSSProperties = {
     display: "flex",
     flexDirection: "row",
-    gap: "max(2px, 1%)",
+    gap: replicas.length < 20 ? "max(2px, 1%)" : "0",
     width: "100%",
     borderRadius: "0.5rem",
     overflow: "hidden",

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -117,9 +117,9 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
         <Typography
           sx={{
             ...menuElementStyle,
-            borderBottom: `1px dashed ${theme.palette.text.primary}`,
+            borderBottom: `1px dashed ${theme.palette.grey[300]}`,
             paddingBottom: "0.2rem",
-            marginBottom: "0.5rem",
+            marginBottom: "0.7rem",
           }}
         >
           {t("replica-status")}

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -12,6 +12,7 @@ export enum ReplicaStatusEnum {
   READY,
   OCCUPIED,
   UNAVAILABLE,
+  WANTED,
 }
 /*
 TODO: Work on width calculation so it doesnt end up janky
@@ -23,6 +24,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
   const theme = useTheme();
   deployment.replicaStatus.availableReplicas = 3;
   deployment.replicaStatus.unavailableReplicas = 5;
+  deployment.replicaStatus.desiredReplicas = 10;
   const replicas = [];
   for (let i in Array.from({
     length: deployment.replicaStatus.readyReplicas,
@@ -40,6 +42,11 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     length: deployment.replicaStatus.unavailableReplicas,
   })) {
     replicas.push(ReplicaStatusEnum.UNAVAILABLE);
+  }
+  for (let i in Array.from({
+    length: deployment.replicaStatus.desiredReplicas - replicas.length,
+  })) {
+    replicas.push(ReplicaStatusEnum.WANTED);
   }
   return (
     <div style={{ position: "relative" }}>
@@ -130,6 +137,14 @@ function ReplicaDetails({ deployment }: { deployment: DeploymentRead }) {
         <span>{t("unavailable") + ":"}</span>
         <span>{deployment.replicaStatus.unavailableReplicas}</span>
       </li>
+      <li style={listElementStyle}>
+        <span>{t("wanted") + ":"}</span>
+        <span>
+          {deployment.replicaStatus.desiredReplicas -
+            (deployment.replicaStatus.unavailableReplicas +
+              deployment.replicaStatus.availableReplicas)}
+        </span>
+      </li>
     </ul>
   );
 }
@@ -159,6 +174,10 @@ function ReplicaDisplay({
     [ReplicaStatusEnum.OCCUPIED]: {
       ...baseStyle,
       backgroundColor: theme?.palette["info"].main,
+    },
+    [ReplicaStatusEnum.WANTED]: {
+      ...baseStyle,
+      backgroundColor: theme?.palette.grey[800],
     },
   };
 

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -89,11 +89,11 @@ function ReplicaDisplay({
   gapInRem?: number;
 }) {
   const baseStyle = {
-    width: `${2/amount}rem`,
+    width: `${2 / amount}rem`,
     height: `2rem`,
-    maxWidth: `${(2/amount - amount) - (gapInRem*amount-gapInRem)} rem`,
+    maxWidth: `${2 / amount - amount - (gapInRem * amount - gapInRem)} rem`,
     borderRadius: borderRadius,
-    color: "rgba(0, 0, 0, 0)"
+    color: "rgba(0, 0, 0, 0)",
   };
 
   const styles = {
@@ -133,7 +133,9 @@ function ReplicaDisplay({
                 ? firstStyles
                 : styles[status]
           }
-        >.</div>
+        >
+          .
+        </div>
       ))}
     </>
   );

--- a/src/pages/edit/deployments/ReplicaStatus.tsx
+++ b/src/pages/edit/deployments/ReplicaStatus.tsx
@@ -37,11 +37,10 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     setExpanded(true);
   };
   const handleClose = () => {
-    setExpanded(false); // shows up d
+    setExpanded(false);
     setAnchorElement(null);
   };
 
-  //deployment.replicaStatus.availableReplicas = 3; // Todo: Change b4 PR
   const replicas = [
     ...Array.from(
       { length: deployment.replicaStatus.readyReplicas },
@@ -85,7 +84,7 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
     display: "flex",
     justifyContent: "space-between",
     gap: "1rem",
-    width: "inherit"
+    width: "inherit",
   };
   return (
     <div style={{ position: "relative" }}>
@@ -109,18 +108,18 @@ export function ReplicaStatus({ deployment }: ReplicaProps) {
         }}
         anchorEl={anchorElement}
         anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
+          vertical: "bottom",
+          horizontal: "right",
         }}
         transformOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
+          vertical: "top",
+          horizontal: "right",
         }}
         open={expanded}
         onClose={handleClose}
         TransitionComponent={Fade}
         disableScrollLock={true}
-        sx={{zIndex:1}}
+        sx={{ zIndex: 1 }}
       >
         {amountReady > 0 && (
           <MenuItem sx={menuElementStyle}>


### PR DESCRIPTION
#272 

Shows the status of a deployments replicas, (if replicas > 1)

## The different statuses
* **Ready**: Amount gotten from `readyReplicas` for replicas that are ready, no current action (showed in green)
* **Occupied**: Amount gotten from `availableReplicas - readyReplicas` for replicas that are doing something (showed in blue)
* **Unavailable**: Amount gotten from `unavailableReplicas` for replicas that are unavailable. (showed in red)
* **Desired**: Amount gotten from `desiredReplicas - (availableReplicas + unavailableReplicas)` for replicas that the user wants but doesnt exist. (showed in grey[800], light grey on dark-mode and dark grey on light mode)

## What have i done
* I created a component `ReplicaStatus.tsx` that is displayed inside the `Edit.tsx` top bar  that gets rendered if the `resource.type` is deployment and there are `> 1` replicas on that deployment.
* Added i18n locale entries in `en.json` and `se.json` for the labels used to describe the statuses.

## Screenshots

### Deployments with short names
![Screenshot from 2024-05-20 22-48-51](https://github.com/kthcloud/console/assets/112874974/b371ae3d-b4d0-4c91-b33f-7b4f889fa070)
### Deployments with longer names
![Screenshot from 2024-05-20 22-49-02](https://github.com/kthcloud/console/assets/112874974/ac96fe3d-52b5-4456-abf4-08470a330644)
### Heres how it looks with more statuses
![Screenshot from 2024-05-20 23-03-06](https://github.com/kthcloud/console/assets/112874974/8171df76-9c05-4402-9832-279f69dc66a0)
###  With many replicas
![Screenshot from 2024-05-20 23-04-47](https://github.com/kthcloud/console/assets/112874974/ee465e13-8f87-4f10-90d6-ca87d2a0d070)
### i18n locale status labels
![image](https://github.com/kthcloud/console/assets/112874974/d76dfc70-5c50-4754-a622-112e75a937d3)


