### PR TITLE
Dont run beta CI on forks

### DIFF
--- a/.github/workflows/kthcloud-ci-beta.yml
+++ b/.github/workflows/kthcloud-ci-beta.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   kthcloud-ci-beta:
+    if: github.repository == "kthcloud/console"
     runs-on: ubuntu-latest
     steps:
       - name: Set release env


### PR DESCRIPTION
Prevents running beta CI on forks, since they will just fail due to the secrets not being available.