### PR TITLE
Add copy user ID button to profile, closes #281

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -7,16 +7,21 @@ import { useTranslation } from "react-i18next";
 const CopyButton = ({
   content,
   variant = "icon",
+  textContent,
 }: {
   content: string;
   variant?: string;
+  textContent?: string;
 }) => {
   const [tooltipLabel, setTooltipLabel] = useState("copy-to-clipboard");
+  const [icon, setIcon] = useState<string>("ic:round-content-copy");
   const { t } = useTranslation();
 
   const handleCopy = () => {
+    setIcon("ic:round-check");
     setTooltipLabel("copied");
     setTimeout(() => {
+      setIcon("ic:round-content-copy");
       setTooltipLabel("copy-to-clipboard");
     }, 2000);
   };
@@ -26,7 +31,7 @@ const CopyButton = ({
       <Tooltip enterTouchDelay={10} title={t(tooltipLabel)}>
         {variant === "icon" ? (
           <IconButton>
-            <Iconify icon={"ic:round-content-copy"} width={24} height={24} />
+            <Iconify icon={icon} width={24} height={24} />
           </IconButton>
         ) : (
           <Button
@@ -37,11 +42,9 @@ const CopyButton = ({
                 ? variant
                 : "text"
             }
-            startIcon={
-              <Iconify icon={"material-symbols:content-copy-outline"} />
-            }
+            startIcon={<Iconify icon={icon} />}
           >
-            {t("copy")}
+            {textContent ? textContent : t("copy")}
           </Button>
         )}
       </Tooltip>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -524,6 +524,10 @@
         "occupied": "Occupied",
         "unavailable": "Unavailable",
         "desired": "Desired",
-        "replica-status": "Replica status"
+        "replica-status": "Replica status",
+        "copy-user-id": "User ID",
+        "error-copying-user-id": "Could not copy user ID",
+        "copied-user-id": "Copied user ID",
+        "error-copying-user-id-user-is-null": "Could not copy user ID from user since user is null"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -523,6 +523,10 @@
         "occupied": "Upptagna",
         "unavailable": "Otillgängliga",
         "desired": "Önskade",
-        "replica-status": "Status på kopior"
+        "replica-status": "Status på kopior",
+        "copy-user-id": "Användar ID",
+        "error-copying-user-id": "Kunde inte kopiera användar ID",
+        "copied-user-id": "Kopierade användar ID",
+        "error-copying-user-id-user-is-null": "Kunde inte kopiera användar ID eftersom användaren är null"
     }
 }

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -158,35 +158,6 @@ export function Profile() {
     reader.readAsText(path[0]);
   };
 
-  const [copyIcon, setCopyIcon] = useState<string>("ic:round-content-copy");
-
-  const copyUserIDToClipBoard = () => {
-    if (user === null) {
-      enqueueSnackbar(t("error-copying-user-id-user-is-null"), {
-        variant: "error",
-      });
-      return;
-    }
-    navigator.clipboard
-      .writeText(user?.id)
-      .then(() => {
-        setCopyIcon("ic:round-check");
-        setTimeout(() => {
-          setCopyIcon("ic:round-content-copy");
-        }, 1500);
-      })
-      .then(() => {
-        enqueueSnackbar(t("copied-user-id"), {
-          variant: "success",
-        });
-      })
-      .catch((error) => {
-        enqueueSnackbar(t("error-copying-user-id") + ", " + error, {
-          variant: "error",
-        });
-      });
-  };
-
   return (
     <>
       {!user ? (
@@ -296,12 +267,11 @@ export function Profile() {
                         {t("security-details")}
                       </Button>
 
-                      <Button
-                        startIcon={<Iconify icon={copyIcon} />}
-                        onClick={copyUserIDToClipBoard}
-                      >
-                        {t("copy-user-id")}
-                      </Button>
+                      <CopyButton
+                        content={user.id}
+                        textContent={t("copy-user-id")}
+                        variant="text"
+                      />
 
                       <div style={{ flexGrow: "1" }} />
                     </Stack>

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -158,6 +158,35 @@ export function Profile() {
     reader.readAsText(path[0]);
   };
 
+  const [copyIcon, setCopyIcon] = useState<string>("ic:round-content-copy");
+
+  const copyUserIDToClipBoard = () => {
+    if (user === null) {
+      enqueueSnackbar(t("error-copying-user-id-user-is-null"), {
+        variant: "error",
+      });
+      return;
+    }
+    navigator.clipboard
+      .writeText(user?.id)
+      .then(() => {
+        setCopyIcon("ic:round-check");
+        setTimeout(() => {
+          setCopyIcon("ic:round-content-copy");
+        }, 1500);
+      })
+      .then(() => {
+        enqueueSnackbar(t("copied-user-id"), {
+          variant: "success",
+        });
+      })
+      .catch((error) => {
+        enqueueSnackbar(t("error-copying-user-id") + ", " + error, {
+          variant: "error",
+        });
+      });
+  };
+
   return (
     <>
       {!user ? (
@@ -265,6 +294,13 @@ export function Profile() {
                         variant="outlined"
                       >
                         {t("security-details")}
+                      </Button>
+
+                      <Button
+                        startIcon={<Iconify icon={copyIcon} />}
+                        onClick={copyUserIDToClipBoard}
+                      >
+                        {t("copy-user-id")}
                       </Button>
 
                       <div style={{ flexGrow: "1" }} />


### PR DESCRIPTION
Hi!

I added a button to copy user ID in the profile page, like described in #281
It adds a snackbar entry message if it succeeds or fails. 

For example if user is null it will say:
![image](https://github.com/kthcloud/console/assets/112874974/129e13e5-24ef-49fd-b1de-37acbe949fc3)

or if 
```javascript
navigator.clipboard.writeText(user.id);
```
throws an error, it will show this message (error message is the message of the error thrown):
![Screenshot from 2024-05-22 01-11-51](https://github.com/kthcloud/console/assets/112874974/9014914a-721c-4f66-b4b3-50ddff3948af)

## Here's how it looks (in glorious GIF quality):

### English
![Screencast-from-2024-05-22-00-42-24](https://github.com/kthcloud/console/assets/112874974/ef42e504-f21a-4f91-b7b7-47441c627ca7)
### Swedish
![Screencast-from-2024-05-22-00-42-40](https://github.com/kthcloud/console/assets/112874974/a2572702-e327-44bc-b1a2-b9c6b0838698)

Lmk if I should change anything :)
