### PR TITLE
Hide GPU page from users without permissions

### DIFF
--- a/src/layouts/dashboard/Menu.tsx
+++ b/src/layouts/dashboard/Menu.tsx
@@ -80,13 +80,15 @@ export default function Menu() {
               >
                 {t("menu-dashboard")}
               </MenuItem>
-              <MenuItem
-                to={"/gpu"}
-                component={RouterLink}
-                onClick={handleClose}
-              >
-                {t("gpu-leases")}
-              </MenuItem>
+              {(user.role.permissions.includes("useGpus") || user.admin) && (
+                <MenuItem
+                  to={"/gpu"}
+                  component={RouterLink}
+                  onClick={handleClose}
+                >
+                  {t("gpu-leases")}
+                </MenuItem>
+              )}
               <MenuItem
                 to={"/create"}
                 component={RouterLink}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -527,6 +527,7 @@
         "copy-user-id": "User ID",
         "error-copying-user-id": "Could not copy user ID",
         "copied-user-id": "Copied user ID",
-        "error-copying-user-id-user-is-null": "Could not copy user ID from user since user is null"
+        "error-copying-user-id-user-is-null": "Could not copy user ID from user since user is null",
+        "not-permitted-to-gpu-page": "Cannot access GPU page: Not allowed to use GPUs"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -526,6 +526,7 @@
         "copy-user-id": "Användar ID",
         "error-copying-user-id": "Kunde inte kopiera användar ID",
         "copied-user-id": "Kopierade användar ID",
-        "error-copying-user-id-user-is-null": "Kunde inte kopiera användar ID eftersom användaren är null"
+        "error-copying-user-id-user-is-null": "Kunde inte kopiera användar ID eftersom användaren är null",
+        "not-permitted-to-gpu-page": "Kan inte komma åt GPU sidan: Inte tillåten att använda GPUer"
     }
 }

--- a/src/pages/deploy/Deploy.tsx
+++ b/src/pages/deploy/Deploy.tsx
@@ -454,13 +454,15 @@ export function Deploy() {
                   {t("storage-manager")}
                 </Button>
               )}
-              <Button
-                component={RouterLink}
-                to={"/gpu"}
-                startIcon={<Iconify icon={"mdi:gpu"} />}
-              >
-                {t("gpu-leases")}
-              </Button>
+              {(user.role.permissions.includes("useGpus") || user.admin) && (
+                <Button
+                  component={RouterLink}
+                  to={"/gpu"}
+                  startIcon={<Iconify icon={"mdi:gpu"} />}
+                >
+                  {t("gpu-leases")}
+                </Button>
+              )}
               <Button
                 component={RouterLink}
                 to="/create"

--- a/src/pages/gpu/GPU.tsx
+++ b/src/pages/gpu/GPU.tsx
@@ -40,7 +40,7 @@ import {
   GpuLeaseRead,
 } from "@kthcloud/go-deploy-types/types/v2/body";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { AlertList } from "../../components/AlertList";
 
 export const GPU = () => {
@@ -60,6 +60,19 @@ export const GPU = () => {
     zones?: string[];
   }
   const [groupedGpus, setGroupedGpus] = useState<GPUGroup[]>([]);
+
+  const { user } = useResource();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) return;
+    if (!user.role.permissions.includes("useGpus") && !user.admin) {
+      enqueueSnackbar(t("not-permitted-to-gpu-page"), {
+        variant: "error",
+      });
+      navigate("/deploy");
+    }
+  }, [user]);
 
   useEffect(() => {
     const grouped: GPUGroup[] = [];


### PR DESCRIPTION
# Hide GPU page from users without useGpus permission and not admin
#242 
If a users role.permissions does not include "useGpus" and user is not an admin they will be redirected from the `/gpu` page if they try to access it, the button doesnt get rendered if the user isn't either an admin or has the useGpus permission.

I used "useGpus" as the permission to check since to my knowledge it is the permission that is present in the role.permissions array if a user should be able to access GPUs. Got it from [here](https://github.com/kthcloud/go-deploy/blob/ee2eed2febb6127b2f04ed9f784bd02833e72e8c/routers/api/v2/gpu_lease.go#L184C2-L184C63) and [here](https://github.com/kthcloud/go-deploy/blob/ee2eed2febb6127b2f04ed9f784bd02833e72e8c/models/model/permissions.go#L7). Let me know if I misunderstood or if there are more permissions that needs to be checked.

The logic for redirecting a user when they try to access the page is inspired from the way it is handled in the admin page, and looks like this.
```javascript
  useEffect(() => {
    if (!user) return;
    if (!user.role.permissions.includes("useGpus") && !user.admin) {
      enqueueSnackbar(t("not-permitted-to-gpu-page"), {
        variant: "error",
      });
      navigate("/deploy");
    }
  }, [user]);
```

**user without "useGpus" in their permissions array sees:**
![image](https://github.com/kthcloud/console/assets/112874974/2a8edf2d-4d08-42f7-a880-f9ed4e7c94b6)
**user without permissions trying to access it through the url in english** 
![image](https://github.com/kthcloud/console/assets/112874974/690f888c-08a0-46d5-b0d8-a9e8a9288e3f)
**user without permissions trying to access it through the url in swedish** 
![image](https://github.com/kthcloud/console/assets/112874974/db2fe64c-9e97-41b9-85da-1cb070786067)

