### PR TITLE
Whitespace nowrap on x-scrollable tables

### DIFF
--- a/src/components/NoWrapTable.tsx
+++ b/src/components/NoWrapTable.tsx
@@ -1,6 +1,6 @@
 import { Table, styled } from "@mui/material";
 
-const NoWrapTable = styled(Table)({
+export const NoWrapTable = styled(Table)({
   whiteSpace: "nowrap",
 });
 

--- a/src/components/NoWrapTable.tsx
+++ b/src/components/NoWrapTable.tsx
@@ -1,0 +1,7 @@
+import { Table, styled } from "@mui/material";
+
+const NoWrapTable = styled(Table)({
+  whiteSpace: "nowrap",
+});
+
+export default NoWrapTable;

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -9,7 +9,6 @@ import {
   Container,
   Link,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -44,6 +43,7 @@ import { deleteGpuLease, listGpuLeases } from "../../api/deploy/gpuLeases";
 import { sentenceCase } from "change-case";
 import { getReasonPhrase } from "http-status-codes";
 import ConfirmButton from "../../components/ConfirmButton";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 export const Admin = () => {
   const { t } = useTranslation();

--- a/src/pages/create/CreateDeployment.tsx
+++ b/src/pages/create/CreateDeployment.tsx
@@ -12,7 +12,6 @@ import {
   TableBody,
   IconButton,
   Paper,
-  Table,
   Stack,
   Switch,
   FormControlLabel,
@@ -29,6 +28,7 @@ import useResource from "../../hooks/useResource";
 import ZoneSelector from "./ZoneSelector";
 import { useTranslation } from "react-i18next";
 import { Volume } from "@kthcloud/go-deploy-types/types/v2/body";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 export default function CreateDeployment({
   finished,

--- a/src/pages/create/ResourceComparisonTable.tsx
+++ b/src/pages/create/ResourceComparisonTable.tsx
@@ -7,7 +7,6 @@ import {
   IconButton,
   Paper,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -22,6 +21,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Iconify from "../../components/Iconify";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 const ResourceComparisonTable = () => {
   const { t } = useTranslation();

--- a/src/pages/deploy/Deploy.tsx
+++ b/src/pages/deploy/Deploy.tsx
@@ -1,7 +1,6 @@
 // mui
 import {
   Card,
-  Table,
   Stack,
   Checkbox,
   TableRow,
@@ -46,6 +45,7 @@ import { Deployment, Resource, Uuid, Vm } from "../../types";
 import { ThemeColor } from "../../theme/types";
 import { deleteVM } from "../../api/deploy/vms";
 import { AlertList } from "../../components/AlertList";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 const descendingComparator = (
   a: Record<string, any>,

--- a/src/pages/edit/deployments/DomainManager.tsx
+++ b/src/pages/edit/deployments/DomainManager.tsx
@@ -16,7 +16,6 @@ import {
   Step,
   StepLabel,
   Stepper,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -38,6 +37,7 @@ import { toUnicode } from "punycode";
 import { useTranslation } from "react-i18next";
 import { sentenceCase } from "change-case";
 import { Deployment } from "../../../types";
+import { NoWrapTable as Table } from "../../../components/NoWrapTable";
 
 export const DomainManager = ({ deployment }: { deployment: Deployment }) => {
   const { t } = useTranslation();

--- a/src/pages/edit/deployments/EnvManager.tsx
+++ b/src/pages/edit/deployments/EnvManager.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
@@ -26,6 +25,7 @@ import { errorHandler } from "../../../utils/errorHandler";
 import { useTranslation } from "react-i18next";
 import { Deployment } from "../../../types";
 import { Env } from "@kthcloud/go-deploy-types/types/v2/body";
+import { NoWrapTable as Table } from "../../../components/NoWrapTable";
 
 export default function EnvManager({ deployment }: { deployment: Deployment }) {
   const { t } = useTranslation();

--- a/src/pages/edit/deployments/GHActions.tsx
+++ b/src/pages/edit/deployments/GHActions.tsx
@@ -13,7 +13,6 @@ import {
   Link,
   Paper,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -28,6 +27,7 @@ import { useTranslation } from "react-i18next";
 import CopyButton from "../../../components/CopyButton";
 import { Deployment } from "../../../types";
 import { CustomTheme } from "../../../theme/types";
+import { NoWrapTable as Table } from "../../../components/NoWrapTable";
 
 type Secret = {
   name: string;

--- a/src/pages/edit/vms/PortManager.tsx
+++ b/src/pages/edit/vms/PortManager.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
@@ -32,6 +31,7 @@ import { useTranslation } from "react-i18next";
 import CopyButton from "../../../components/CopyButton";
 import { Port, Vm } from "../../../types";
 import { PortUpdate } from "@kthcloud/go-deploy-types/types/v2/body";
+import { NoWrapTable as Table } from "../../../components/NoWrapTable";
 
 export default function PortManager({ vm }: { vm: Vm }) {
   const { t } = useTranslation();

--- a/src/pages/edit/vms/ProxyManager.tsx
+++ b/src/pages/edit/vms/ProxyManager.tsx
@@ -21,7 +21,6 @@ import {
   Select,
   Skeleton,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -49,6 +48,7 @@ import {
   PortRead,
   PortUpdate,
 } from "@kthcloud/go-deploy-types/types/v2/body";
+import { NoWrapTable as Table } from "../../../components/NoWrapTable";
 
 interface Proxy extends HttpProxyRead {
   port?: number;

--- a/src/pages/gpu/GPU.tsx
+++ b/src/pages/gpu/GPU.tsx
@@ -15,7 +15,6 @@ import {
   MenuItem,
   Select,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -42,6 +41,7 @@ import {
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { AlertList } from "../../components/AlertList";
+import NoWrapTable from "../../components/NoWrapTable";
 
 export const GPU = () => {
   const { t } = useTranslation();
@@ -247,7 +247,7 @@ export const GPU = () => {
                 />
                 <CardContent>
                   <TableContainer>
-                    <Table>
+                    <NoWrapTable>
                       <TableHead>
                         <TableRow>
                           <TableCell>{t("admin-name")}</TableCell>
@@ -347,7 +347,7 @@ export const GPU = () => {
                           </TableRow>
                         )}
                       </TableBody>
-                    </Table>
+                    </NoWrapTable>
                   </TableContainer>
                 </CardContent>
               </Card>
@@ -359,7 +359,7 @@ export const GPU = () => {
                 />
                 <CardContent>
                   <TableContainer>
-                    <Table>
+                    <NoWrapTable>
                       <TableHead>
                         <TableRow>
                           <TableCell>{t("admin-name")}</TableCell>
@@ -413,7 +413,7 @@ export const GPU = () => {
                           </TableRow>
                         )}
                       </TableBody>
-                    </Table>
+                    </NoWrapTable>
                   </TableContainer>
                 </CardContent>
               </Card>

--- a/src/pages/inbox/Inbox.tsx
+++ b/src/pages/inbox/Inbox.tsx
@@ -8,7 +8,6 @@ import {
   Paper,
   Skeleton,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -35,6 +34,7 @@ import { errorHandler } from "../../utils/errorHandler";
 import { useTheme } from "@mui/material/styles";
 import { NotificationRead } from "@kthcloud/go-deploy-types/types/v2/body";
 import { AlertList } from "../../components/AlertList";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 const Inbox = () => {
   const { user, notifications, unread, beginFastLoad } = useResource();

--- a/src/pages/profile/ApiKeys.tsx
+++ b/src/pages/profile/ApiKeys.tsx
@@ -15,7 +15,6 @@ import {
   Select,
   Skeleton,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -37,6 +36,7 @@ import { enqueueSnackbar } from "notistack";
 import { useKeycloak } from "@react-keycloak/web";
 import { ApiKeyCreated } from "@kthcloud/go-deploy-types/types/v2/body";
 import CopyButton from "../../components/CopyButton";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 export const ApiKeys = () => {
   const { t } = useTranslation();

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import Iconify from "../../components/Iconify";
-import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
@@ -45,6 +44,7 @@ import { useTranslation } from "react-i18next";
 import { User } from "../../types";
 import { ApiKeys } from "./ApiKeys";
 import { AlertList } from "../../components/AlertList";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 export function Profile() {
   const { t } = useTranslation();

--- a/src/pages/teams/Teams.tsx
+++ b/src/pages/teams/Teams.tsx
@@ -13,7 +13,6 @@ import {
   Paper,
   Skeleton,
   Stack,
-  Table,
   TableBody,
   TableCell,
   TableContainer,
@@ -52,6 +51,7 @@ import {
   UserReadDiscovery,
 } from "@kthcloud/go-deploy-types/types/v2/body";
 import { AlertList } from "../../components/AlertList";
+import { NoWrapTable as Table } from "../../components/NoWrapTable";
 
 const Teams = () => {
   const { user, teams, beginFastLoad } = useResource();


### PR DESCRIPTION
# Whitespace nowrap on x-scrollable tables
#298 
Created a wrapper component for Table that just sets whiteSpace: 'nowrap' on the styling and all the imports from Table to 'NoWrapTable as Table' except for StorageManager since i thought it seemed tedious to scroll long file paths, let me know what you think about that.

**ADMIN**
![image](https://github.com/kthcloud/console/assets/112874974/5e43c670-7043-4b4b-9704-64d54023e498)

**CREATE DEPLOYMENT**
![image](https://github.com/kthcloud/console/assets/112874974/f698f03b-6d41-479e-a024-24f8e21ca85e)

**RESOURCE COMPARISON TABLE**
![image](https://github.com/kthcloud/console/assets/112874974/4e810c3f-85fc-4ecf-b94a-246ae67584e3)

**DEPLOY**
![image](https://github.com/kthcloud/console/assets/112874974/cc4825d7-ab65-4e7e-b06f-23c9a52ea47a)

**DOMAIN MANAGER**
![image](https://github.com/kthcloud/console/assets/112874974/e2aff7b1-a27a-41d1-a9db-8d0b48529454)

**ENV MANAGER**
![image](https://github.com/kthcloud/console/assets/112874974/f26eb940-88d2-49a8-b54b-61883f769985)

**STORAGE MANAGER**
(not changed)

**PORT MANAGER**
![image](https://github.com/kthcloud/console/assets/112874974/7f515181-a8dc-4361-8e0f-965fdebd668e)


**GPU**
![image](https://github.com/kthcloud/console/assets/112874974/14193e5a-cae4-4129-92da-cce04a02a0c3)

