### PR TITLE
Check if run arguments exceed 100 and display an error on the input

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -531,6 +531,7 @@
         "error-copying-user-id-user-is-null": "Could not copy user ID from user since user is null",
         "not-permitted-to-gpu-page": "Cannot access GPU page: Not allowed to use GPUs",
         "nothing-to-do": "Nothing to do",
-        "image-tag": "Image tag"
+        "image-tag": "Image tag",
+        "too-many-run-args": "Too many run args, max 100"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -530,6 +530,7 @@
         "not-permitted-to-gpu-page": "Kan inte komma åt GPU sidan: Inte tillåten att använda GPUer",
         "run-args": "Argument till körning",
         "nothing-to-do": "Inget att göra",
-        "image-tag": "Image tagg"
+        "image-tag": "Image tagg",
+        "too-many-run-args": "För många argument, max 100"
     }
 }

--- a/src/pages/edit/deployments/ImageManager.tsx
+++ b/src/pages/edit/deployments/ImageManager.tsx
@@ -72,7 +72,8 @@ export const ImageManager = ({ deployment }: { deployment: Deployment }) => {
   };
 
   useEffect(() => {
-    if (imageArgs.split(" ").length > 100) {
+    const length = imageArgs.split(" ").length;
+    if (length > 100 && imageArgs.split(" ")[length - 1] !== "") {
       setTooManyArgs(true);
     } else if (tooManyArgs) {
       setTooManyArgs(false);

--- a/src/pages/edit/deployments/ImageManager.tsx
+++ b/src/pages/edit/deployments/ImageManager.tsx
@@ -1,13 +1,5 @@
 import { LoadingButton } from "@mui/lab";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  Stack,
-  TextField,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Card, CardContent, CardHeader, Stack, TextField } from "@mui/material";
 import { useKeycloak } from "@react-keycloak/web";
 import { enqueueSnackbar } from "notistack";
 import { useEffect, useState } from "react";
@@ -73,7 +65,7 @@ export const ImageManager = ({ deployment }: { deployment: Deployment }) => {
 
   useEffect(() => {
     const length = imageArgs.split(" ").length;
-    if (length > 100 && imageArgs.split(" ")[length - 1] !== "") {
+    if (length > 2 && imageArgs.split(" ")[length - 1] !== "") {
       setTooManyArgs(true);
     } else if (tooManyArgs) {
       setTooManyArgs(false);


### PR DESCRIPTION
# Check if run arguments exceed 100 and display an error on the input and enque an error if the user tries to save their args with length > 100.

Just added a little check that makes sure the user gets alerted if `imageArgs` exceed 100, since it is the max in go-deploy.

It looks like this (changed it to 2 for displaying purposes):
![image](https://github.com/kthcloud/console/assets/112874974/9bbd48b5-2bad-4c02-bfb8-452d2fd4cbef)
![image](https://github.com/kthcloud/console/assets/112874974/29011f32-c9ee-4451-8932-6e06e8ddc5f5)
![image](https://github.com/kthcloud/console/assets/112874974/922eed0e-a612-4e68-962f-b3a76226c25a)
