### PR TITLE
Handle iam outage more gracefully, related to #321

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // keycloak
-import { ReactKeycloakProvider } from "@react-keycloak/web";
+import { AuthContextWrapperProvider } from "./contexts/AuthContextWrapper";
 import { keycloak } from "./keycloak";
 // routes
 import Router from "./Router";
@@ -17,7 +17,7 @@ import { AlertContextProvider } from "./contexts/AlertContext";
 
 export default function App() {
   return (
-    <ReactKeycloakProvider authClient={keycloak}>
+    <AuthContextWrapperProvider authClient={keycloak}>
       <AlertContextProvider>
         <ResourceContextProvider>
           <ThemeModeContextProvider>
@@ -45,6 +45,6 @@ export default function App() {
           </ThemeModeContextProvider>
         </ResourceContextProvider>
       </AlertContextProvider>
-    </ReactKeycloakProvider>
+    </AuthContextWrapperProvider>
   );
 }

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,12 +1,15 @@
 import { Navigate } from "react-router-dom";
 import { useKeycloak } from "@react-keycloak/web";
 import LoadingPage from "./LoadingPage";
+import { useContext } from "react";
+import { AuthContextWrapper } from "../contexts/AuthContextWrapper";
 
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
+  const { error } = useContext(AuthContextWrapper);
   const { keycloak, initialized } = useKeycloak();
 
   const renderPage = (children: React.ReactNode) => {
-    if (!initialized) {
+    if (!initialized && !error) {
       return <LoadingPage />;
     } else if (initialized && keycloak.authenticated) {
       return children;

--- a/src/contexts/AuthContextWrapper.tsx
+++ b/src/contexts/AuthContextWrapper.tsx
@@ -1,0 +1,48 @@
+// keycloak
+import { ReactKeycloakProvider } from "@react-keycloak/web";
+import Keycloak from "keycloak-js";
+
+import {
+  AuthClientEvent,
+  AuthClientError,
+} from "@react-keycloak/core/lib/types";
+import { createContext, useState } from "react";
+
+type AuthContextWrapperType = {
+  events: AuthClientEvent[];
+  error?: AuthClientError;
+};
+
+const initialState: AuthContextWrapperType = {
+  events: [],
+};
+
+export const AuthContextWrapper = createContext(initialState);
+
+export const AuthContextWrapperProvider = ({
+  authClient,
+  children,
+}: {
+  authClient: Keycloak;
+  children: React.ReactNode;
+}) => {
+  const [events, setEvents] = useState<AuthClientEvent[]>([]);
+  const [error, setError] = useState<AuthClientError | undefined>(undefined);
+
+  const handleEvent = (
+    event: AuthClientEvent,
+    error: AuthClientError | undefined
+  ) => {
+    setEvents([...events, event]);
+    if (error) {
+      setError(error);
+    }
+  };
+  return (
+    <AuthContextWrapper.Provider value={{ events, error }}>
+      <ReactKeycloakProvider authClient={authClient} onEvent={handleEvent}>
+        {children}
+      </ReactKeycloakProvider>
+    </AuthContextWrapper.Provider>
+  );
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -534,6 +534,7 @@
         "too-many-run-args": "Too many run args, max 100",
         "pending-migrations": "Pending migrations",
         "migration": "Migration",
-        "of": "of"
+        "of": "of",
+        "error-connecting-to-iam": "Error connecting to IAM"
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -533,6 +533,7 @@
         "too-many-run-args": "För många argument, max 100",
         "pending-migrations": "Pågående överföringar",
         "migration": "Överföring",
-        "of": "av"
+        "of": "av",
+        "error-connecting-to-iam": "Fel vid anslutning till IAM"
     }
 }

--- a/src/pages/landing/Landing.tsx
+++ b/src/pages/landing/Landing.tsx
@@ -6,11 +6,23 @@ import { useKeycloak } from "@react-keycloak/web";
 import LoadingPage from "../../components/LoadingPage";
 import Funding from "./components/funding/Funding";
 import { AlertList } from "../../components/AlertList";
+import { useContext, useEffect } from "react";
+import { AuthContextWrapper } from "../../contexts/AuthContextWrapper";
+import { enqueueSnackbar } from "notistack";
+import { useTranslation } from "react-i18next";
 
 export function Landing() {
   const { keycloak, initialized } = useKeycloak();
+  const { error } = useContext(AuthContextWrapper);
+  const { t } = useTranslation();
 
-  if (!initialized) {
+  useEffect(() => {
+    if (error) {
+      enqueueSnackbar(t("error-connecting-to-iam"), { variant: "error" });
+    }
+  }, [error, enqueueSnackbar]);
+
+  if (!initialized && !error) {
     return (
       <Page>
         <Box component="div" sx={{ minHeight: "100vh" }}></Box>


### PR DESCRIPTION
# Handle iam outage more gracefully, related to #321

* Created a context that wraps `ReactKeycloakProvider` and makes `AuthClientEvents` and `AuthClientErrors` available. 
* Implemented a check if there is an error inside `ProtectedRoute.tsx` and if there is an error just redirect to `/` (the landing page).
* In the landing page a snackbar will be enqueued if an error (from the `AuthContextWrapper`) is present, and the landing page will appear as if you are logged out.

## Some considerations I have:

Is wrapping the `ReactKeycloakProvider` a good solution? Or should it be solved in another way? Might be possible to do it a bit neater, I am currently just doing it like this: (*also: events could just be one singular event*) 
```TypeScript
const [events, setEvents] = useState<AuthClientEvent[]>([]);
const [error, setError] = useState<AuthClientError | undefined>(undefined);

const handleEvent = (
  event: AuthClientEvent,
  error: AuthClientError | undefined
) => {
  setEvents([...events, event]);
  if (error) {
    setError(error);
  }
};
return (
  <AuthContextWrapper.Provider value={{ events, error }}>
    <ReactKeycloakProvider authClient={authClient} onEvent={handleEvent}>
      {children}
    </ReactKeycloakProvider>
  </AuthContextWrapper.Provider>
);
  
```

It still takes a while until the `ReactKeycloakProvider` calls the `onEvent` callback I am using, I am not sure why that is the case. 

Should it redirect to the landing page and display a message like i've implemented it now (a snackbar is enqueued). Or should it display a separate page/modal/dialog where maybe a link could be added to the [uptimerobot site](https://stats.uptimerobot.com/rxDyoUwXOm).

Lmk what you think

Related to #321 
