### PR TITLE
Visibility modes, closes #322

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -535,8 +535,9 @@
         "pending-migrations": "Pending migrations",
         "migration": "Migration",
         "of": "of",
-        "admin-visibility-private-teams": "Private (Teams)",
-        "admin-visibility-private-self": "Private (Only you)",
-        "admin-visibility-hidden": "Hidden"
+        "admin-visibility-auth": "Private (auth proxy)",
+        "visibility-public-tooltip": "Your deployment is publicly accessible on the internet.",
+        "visibility-private-tooltip": "Your deployment is private and not reachable on the internet. Only internal traffic is allowed in (traffic between deployments).",
+        "visibility-auth-tooltip": "Your deployment is private and reacheble on the internet through an authentication proxy, this limits the allowed traffic."
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -207,7 +207,7 @@
         "line-wrap": "Line wrap",
         "visibility-saving": "Saving visibility...",
         "could-not-save-visibility": "Could not save visibility: ",
-        "visibility-subheader": "Choose whether to make this deployment hidden from the internet",
+        "visibility-subheader": "Choose the visibility level of this deployment",
         "lease-gpu": "Lease GPU",
         "lease-gpu-forever": "Lease GPU forever",
         "renew-gpu-lease": "Renew GPU lease",
@@ -534,6 +534,9 @@
         "too-many-run-args": "Too many run args, max 100",
         "pending-migrations": "Pending migrations",
         "migration": "Migration",
-        "of": "of"
+        "of": "of",
+        "admin-visibility-private-teams": "Private (Teams)",
+        "admin-visibility-private-self": "Private (Only you)",
+        "admin-visibility-hidden": "Hidden"
     }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -538,6 +538,6 @@
         "admin-visibility-auth": "Private (auth proxy)",
         "visibility-public-tooltip": "Your deployment is publicly accessible on the internet.",
         "visibility-private-tooltip": "Your deployment is private and not reachable on the internet. Only internal traffic is allowed in (traffic between deployments).",
-        "visibility-auth-tooltip": "Your deployment is private and reacheble on the internet through an authentication proxy, this limits the allowed traffic."
+        "visibility-auth-tooltip": "Your deployment is private and reachable on the internet through an authentication proxy, this limits the allowed traffic."
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -534,8 +534,9 @@
         "pending-migrations": "Pågående överföringar",
         "migration": "Överföring",
         "of": "av",
-        "admin-visibility-private-teams": "Privat (Grupp)",
-        "admin-visibility-private-self": "Privat (Bara du)",
-        "admin-visibility-hidden": "Gömd"
+        "admin-visibility-auth": "Privat (auth proxy)",
+        "visibility-public-tooltip": "Din deployment är publikt åtkomlig på internet.",
+        "visibility-private-tooltip": "Din deployment är privat och inte åtkomlig på internet. Enbart intern trafik mellan appar är tillåten.",
+        "visibility-auth-tooltip": "Din deployment är privat och åtkomlig på internet via en autentiserings-proxy, detta begränsar tillåten trafik."
     }
 }

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -151,7 +151,7 @@
         "menu-manage-resources": "Hantera resurser",
         "error-could-not-fetch-gpus": "Kunde inte hämta grafikkort",
         "could-not-fetch-profile": "Profilen kunde inte hämtas: ",
-        "visibility-subheader": "Välj om din app ska synas på webben",
+        "visibility-subheader": "Välj synlighetsnivån av din deployment",
         "secrets": "hemligheter",
         "onboarding-resources": "Resurser på kthcloud",
         "deleting": "Raderar...",
@@ -533,6 +533,9 @@
         "too-many-run-args": "För många argument, max 100",
         "pending-migrations": "Pågående överföringar",
         "migration": "Överföring",
-        "of": "av"
+        "of": "av",
+        "admin-visibility-private-teams": "Privat (Grupp)",
+        "admin-visibility-private-self": "Privat (Bara du)",
+        "admin-visibility-hidden": "Gömd"
     }
 }

--- a/src/pages/edit/deployments/PrivateMode.tsx
+++ b/src/pages/edit/deployments/PrivateMode.tsx
@@ -16,7 +16,7 @@ import { errorHandler } from "../../../utils/errorHandler";
 import { useTranslation } from "react-i18next";
 import { Deployment } from "../../../types";
 
-type visibility = "public" | "private" | "auth" | undefined | string;
+type visibility = "public" | "private" | "auth" | "hidden" | string;
 
 const PrivacyModeSelector = ({
   privacyMode,
@@ -51,7 +51,7 @@ const PrivacyModeSelector = ({
       <ToggleButton value="auth">
         {t("admin-visibility-private-self")}
       </ToggleButton>
-      <ToggleButton value={undefined}>
+      <ToggleButton value={"hidden"}>
         {t("admin-visibility-hidden")}
       </ToggleButton>
     </ToggleButtonGroup>

--- a/src/pages/edit/deployments/PrivateMode.tsx
+++ b/src/pages/edit/deployments/PrivateMode.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   ToggleButtonGroup,
   ToggleButton,
+  Tooltip,
 } from "@mui/material";
 
 import { enqueueSnackbar } from "notistack";
@@ -16,7 +17,7 @@ import { errorHandler } from "../../../utils/errorHandler";
 import { useTranslation } from "react-i18next";
 import { Deployment } from "../../../types";
 
-type visibility = "public" | "private" | "auth" | "hidden" | string;
+type visibility = "public" | "private" | "auth" | string;
 
 const PrivacyModeSelector = ({
   privacyMode,
@@ -44,16 +45,21 @@ const PrivacyModeSelector = ({
       onChange={handleChange}
       aria-label="Platform"
     >
-      <ToggleButton value="public">{t("admin-visibility-public")}</ToggleButton>
-      <ToggleButton value="private">
-        {t("admin-visibility-private-teams")}
-      </ToggleButton>
-      <ToggleButton value="auth">
-        {t("admin-visibility-private-self")}
-      </ToggleButton>
-      <ToggleButton value={"hidden"}>
-        {t("admin-visibility-hidden")}
-      </ToggleButton>
+      <Tooltip enterTouchDelay={10} title={t("visibility-public-tooltip")}>
+        <ToggleButton value="public">
+          {t("admin-visibility-public")}
+        </ToggleButton>
+      </Tooltip>
+      <Tooltip enterTouchDelay={10} title={t("visibility-auth-tooltip")}>
+        <ToggleButton value="auth">
+          <>{t("admin-visibility-auth")}</>
+        </ToggleButton>
+      </Tooltip>
+      <Tooltip enterTouchDelay={10} title={t("visibility-private-tooltip")}>
+        <ToggleButton value="private">
+          {t("admin-visibility-private")}
+        </ToggleButton>
+      </Tooltip>
     </ToggleButtonGroup>
   );
 };
@@ -65,15 +71,15 @@ export const PrivateMode = ({ deployment }: { deployment: Deployment }) => {
   const { initialized, keycloak } = useKeycloak();
   const { queueJob } = useResource();
 
-  const applyChanges = async (checked: visibility) => {
+  const applyChanges = async (visibility: visibility) => {
     if (!(initialized && keycloak.token)) return;
-    setPrivacyMode(checked);
+    setPrivacyMode(visibility);
     setLoading(true);
 
     try {
       const res = await updateDeployment(
         deployment.id,
-        { Visibility: checked },
+        { Visibility: visibility },
         keycloak.token
       );
 


### PR DESCRIPTION
# Added visibility modes toggle buttons on deployment

## Choices added for the modes `public`, `auth` and `private`

![image](https://github.com/user-attachments/assets/7933fe7d-165f-45c7-b615-9e26fab8e642)

The choices are ordered: more public --> more private, I figured that auth proxy is more public than private since auth proxy still allows external traffic if it is authenticated while private only allows internal traffic.

## Tooltips explaining what the different modes do

![Screencast from 2024-08-11 11-08-30](https://github.com/user-attachments/assets/acfc312c-b64e-48ec-8a0c-d825a8e80bce)

Let me know if i have misunderstood the modes or should rewrite the descriptions, this is how i figured they work:

|Mode | Description |
|---------|------------------|
|public|Your deployment is publicly accessible on the internet.|
|auth   |Your deployment is private and reachable on the internet through an authentication proxy, this limits the allowed traffic.|
|private|Your deployment is private and not reachable on the internet. Only internal traffic is allowed in (traffic between deployments).|

