### PR TITLE
Set max resources based on quota - usage, was previously hardcoded

### DIFF
--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -390,7 +390,9 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   <Typography variant="body2" fontFamily="monospace">
                     {resource.type === "vm"
                       ? Math.floor(maxCpu / STEP_VM) * STEP_VM
-                      : Math.floor(maxCpu / STEP_DEPLOYMENT) * STEP_DEPLOYMENT}
+                      : Math.floor(
+                          Number(maxCpu.toPrecision(10)) / STEP_DEPLOYMENT
+                        ) * STEP_DEPLOYMENT}
                   </Typography>
                 </Stack>
               </Grid>
@@ -441,7 +443,9 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   <Typography variant="body2" fontFamily="monospace">
                     {resource.type === "vm"
                       ? Math.floor(maxRam / STEP_VM) * STEP_VM
-                      : Math.floor(maxRam / STEP_DEPLOYMENT) * STEP_DEPLOYMENT}
+                      : Math.floor(
+                          Number(maxRam.toPrecision(10)) / STEP_DEPLOYMENT
+                        ) * STEP_DEPLOYMENT}
                   </Typography>
                 </Stack>
               </Grid>

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -388,7 +388,9 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                     }}
                   />
                   <Typography variant="body2" fontFamily="monospace">
-                    {maxCpu}
+                    {resource.type === "vm"
+                      ? Math.floor(maxCpu / STEP_VM) * STEP_VM
+                      : Math.floor(maxCpu / STEP_DEPLOYMENT) * STEP_DEPLOYMENT}
                   </Typography>
                 </Stack>
               </Grid>
@@ -437,7 +439,9 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   />
 
                   <Typography variant="body2" fontFamily="monospace">
-                    {maxRam}
+                    {resource.type === "vm"
+                      ? Math.floor(maxRam / STEP_VM) * STEP_VM
+                      : Math.floor(maxRam / STEP_DEPLOYMENT) * STEP_DEPLOYMENT}
                   </Typography>
                 </Stack>
               </Grid>

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -79,9 +79,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
         user.usage.cpuCores +
         (resource.specs.cpuCores ?? 0);
       const ramLeft =
-        user.quota.ram -
-        user.usage.ram +
-        (resource.specs.ram ?? 0);
+        user.quota.ram - user.usage.ram + (resource.specs.ram ?? 0);
 
       if (coresLeft !== maxCpu) {
         const currentCores =
@@ -392,9 +390,11 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   <Typography variant="body2" fontFamily="monospace">
                     {resource.type === "vm"
                       ? Math.floor(maxCpu / STEP_VM) * STEP_VM
-                      : (Math.floor(
-                          Number(maxCpu.toPrecision(10)) / STEP_DEPLOYMENT
-                        ) * STEP_DEPLOYMENT).toPrecision(2)}
+                      : (
+                          Math.floor(
+                            Number(maxCpu.toPrecision(10)) / STEP_DEPLOYMENT
+                          ) * STEP_DEPLOYMENT
+                        ).toPrecision(2)}
                   </Typography>
                 </Stack>
               </Grid>
@@ -445,11 +445,12 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   <Typography variant="body2" fontFamily="monospace">
                     {resource.type === "vm"
                       ? Math.floor(maxRam / STEP_VM) * STEP_VM
-                      : (Math.floor(
-                          (Number(maxRam.toPrecision(10)) / STEP_DEPLOYMENT)
-                        ) * STEP_DEPLOYMENT).toPrecision(2)}
+                      : (
+                          Math.floor(
+                            Number(maxRam.toPrecision(10)) / STEP_DEPLOYMENT
+                          ) * STEP_DEPLOYMENT
+                        ).toPrecision(2)}
                   </Typography>
-
                 </Stack>
               </Grid>
             </Grid>

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -55,7 +55,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
   const [maxRam, setMaxRam] = useState<number>(
     resource.type === "vm" ? MAX_RAM_VM : MAX_RAM_DEPLOYMENT
   );
-  const [maxReplicas, setMaxReplicas] = useState<number>(MAX_REPLICAS);
+  const [maxReplicas, _] = useState<number>(MAX_REPLICAS);
 
   const getInitialCpu = () => {
     return resource.specs.cpuCores || 0;
@@ -71,6 +71,30 @@ export const Specs = ({ resource }: { resource: Resource }) => {
 
   const [loading, setLoading] = useState<boolean>(false);
   const [editing, setEditing] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (user) {
+      const coresLeft = user.quota.cpuCores - user.usage.cpuCores;
+      const ramLeft = user.quota.ram - user.usage.ram;
+
+      if (coresLeft !== maxCpu) {
+        const currentCores =
+          resource.specs.cpuCores ??
+          (resource.type === "vm" ? MIN_CPU_VM : MIN_CPU_DEPLOYMENT);
+
+        // make sure that max cant be lower than the current core count
+        setMaxCpu(coresLeft >= currentCores ? coresLeft : currentCores);
+      }
+      if (ramLeft !== maxRam) {
+        const currentRam =
+          resource.specs.ram ??
+          (resource.type === "vm" ? MIN_RAM_VM : MIN_RAM_DEPLOYMENT);
+
+        // make sure that max cant be lower than the current ram amount
+        setMaxRam(ramLeft >= currentRam ? ramLeft : currentRam);
+      }
+    }
+  }, [user, resource]);
 
   const updateSpecs = () => {
     if (resource.type === "deployment") {
@@ -122,15 +146,6 @@ export const Specs = ({ resource }: { resource: Resource }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [cpu, ram, replicas, maxCpu, maxRam, maxReplicas]
   );
-
-  // Set max values
-  useEffect(() => {
-    setMaxCpu(20);
-    setMaxRam(20);
-    setMaxReplicas(20);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resource]);
 
   const isSame = () => {
     if (resource.type === "deployment") {
@@ -342,7 +357,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
               <Grid xs={12}>
                 <Slider
                   value={cpu}
-                  onChange={(_, v) => setCpu(v as number)}
+                  onChange={(_: any, v: any) => setCpu(v as number)}
                   min={resource.type === "vm" ? MIN_CPU_VM : MIN_CPU_DEPLOYMENT}
                   max={maxCpu}
                   step={resource.type === "vm" ? STEP_VM : STEP_DEPLOYMENT}
@@ -389,7 +404,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
               <Grid xs={12}>
                 <Slider
                   value={ram}
-                  onChange={(_, v) => setRam(v as number)}
+                  onChange={(_: any, v: any) => setRam(v as number)}
                   min={resource.type === "vm" ? MIN_RAM_VM : MIN_RAM_DEPLOYMENT}
                   max={maxRam}
                   step={resource.type === "vm" ? STEP_VM : STEP_DEPLOYMENT}
@@ -464,7 +479,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                 <Grid xs={12}>
                   <Slider
                     value={replicas}
-                    onChange={(_, v) => setReplicas(v as number)}
+                    onChange={(_: any, v: any) => setReplicas(v as number)}
                     min={MIN_REPLICAS}
                     max={maxReplicas}
                     step={1}

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -74,8 +74,12 @@ export const Specs = ({ resource }: { resource: Resource }) => {
 
   useEffect(() => {
     if (user) {
-      const coresLeft = user.quota.cpuCores - user.usage.cpuCores;
-      const ramLeft = user.quota.ram - user.usage.ram;
+      const coresLeft =
+        user.quota.cpuCores -
+        user.usage.cpuCores +
+        (resource.specs.cpuCores ?? 0);
+      const ramLeft =
+        user.quota.ram - user.usage.ram + (resource.specs.ram ?? 0);
 
       if (coresLeft !== maxCpu) {
         const currentCores =

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -74,12 +74,18 @@ export const Specs = ({ resource }: { resource: Resource }) => {
 
   useEffect(() => {
     if (user) {
+      const deploymentIsDisabled =
+        resource.type === "vm"
+          ? false
+          : (resource as Deployment).specs.replicas === 0;
       const coresLeft =
         user.quota.cpuCores -
         user.usage.cpuCores +
-        (resource.specs.cpuCores ?? 0);
+        (deploymentIsDisabled ? 0 : resource.specs.cpuCores ?? 0);
       const ramLeft =
-        user.quota.ram - user.usage.ram + (resource.specs.ram ?? 0);
+        user.quota.ram -
+        user.usage.ram +
+        (deploymentIsDisabled ? 0 : resource.specs.ram ?? 0);
 
       if (coresLeft !== maxCpu) {
         const currentCores =

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -74,12 +74,17 @@ export const Specs = ({ resource }: { resource: Resource }) => {
 
   useEffect(() => {
     if (user) {
+      const replicasInUse =
+        resource.type === "vm" ? 1 : (resource as Deployment).specs.replicas;
+
       const coresLeft =
         user.quota.cpuCores -
         user.usage.cpuCores +
-        (resource.specs.cpuCores ?? 0);
+        (resource.specs.cpuCores ?? 0) * replicasInUse;
       const ramLeft =
-        user.quota.ram - user.usage.ram + (resource.specs.ram ?? 0);
+        user.quota.ram -
+        user.usage.ram +
+        (resource.specs.ram ?? 0) * replicasInUse;
 
       if (coresLeft !== maxCpu) {
         const currentCores =
@@ -390,9 +395,9 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   <Typography variant="body2" fontFamily="monospace">
                     {resource.type === "vm"
                       ? Math.floor(maxCpu / STEP_VM) * STEP_VM
-                      : Math.floor(
+                      : (Math.floor(
                           Number(maxCpu.toPrecision(10)) / STEP_DEPLOYMENT
-                        ) * STEP_DEPLOYMENT}
+                        ) * STEP_DEPLOYMENT).toPrecision(2)}
                   </Typography>
                 </Stack>
               </Grid>
@@ -443,10 +448,11 @@ export const Specs = ({ resource }: { resource: Resource }) => {
                   <Typography variant="body2" fontFamily="monospace">
                     {resource.type === "vm"
                       ? Math.floor(maxRam / STEP_VM) * STEP_VM
-                      : Math.floor(
-                          Number(maxRam.toPrecision(10)) / STEP_DEPLOYMENT
-                        ) * STEP_DEPLOYMENT}
+                      : (Math.floor(
+                          (Number(maxRam.toPrecision(10)) / STEP_DEPLOYMENT)
+                        ) * STEP_DEPLOYMENT).toPrecision(2)}
                   </Typography>
+
                 </Stack>
               </Grid>
             </Grid>

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -73,7 +73,7 @@ export const Specs = ({ resource }: { resource: Resource }) => {
   const [editing, setEditing] = useState<boolean>(false);
 
   const toClosestStep = (value: number, step: number) => {
-    return Math.round(Math.round(value / step) * step * 100) / 100;
+    return Math.round(Math.floor(value / step) * step * 100) / 100;
   };
 
   const calculateResourcesLeft = (

--- a/src/pages/edit/Specs.tsx
+++ b/src/pages/edit/Specs.tsx
@@ -74,17 +74,14 @@ export const Specs = ({ resource }: { resource: Resource }) => {
 
   useEffect(() => {
     if (user) {
-      const replicasInUse =
-        resource.type === "vm" ? 1 : (resource as Deployment).specs.replicas;
-
       const coresLeft =
         user.quota.cpuCores -
         user.usage.cpuCores +
-        (resource.specs.cpuCores ?? 0) * replicasInUse;
+        (resource.specs.cpuCores ?? 0);
       const ramLeft =
         user.quota.ram -
         user.usage.ram +
-        (resource.specs.ram ?? 0) * replicasInUse;
+        (resource.specs.ram ?? 0);
 
       if (coresLeft !== maxCpu) {
         const currentCores =


### PR DESCRIPTION
## Set resource limits based on `quota - usage`

Previously the max values for the specs were hardcoded, causing #329.
The issue was caused by this:
```typescript
 // Set max values
  useEffect(() => {
    setMaxCpu(20);
    setMaxRam(20);
    setMaxReplicas(20);

    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [resource]);
```

So i changed it so that the max cpu cores and ram are set based on:
```math 
((the\ users\ quota - the\ users\ usage) + the\ current\ resources\ spec) / replicas.
```
If the current resource exceeds that value it is set as the max-value, so that it doesn't get capped down, (since it is already allowed).

### ~Left Todo~
- [x] handle multiple replicas
- [x] change on changes to values before submitting

### How it looks

**Editing a deployment with 1 replica**
1.8 cores left to use across one deployment => 1.8 cores max per replica
![image](https://github.com/user-attachments/assets/75f7e2b2-17d7-4aa3-8473-4bfef43d7742)
**Editing a deployment with 2 replicas**
1.8 cores left to use across two deployment => 0.8 cores max per replica *rounded down to step for the resource type, which is 0.2 for deployments and 1 for vms.*
![image](https://github.com/user-attachments/assets/cec1153a-ca78-49ed-8576-fed3fb75dabf)
**Editing a disabled deployments specs**
![image](https://github.com/user-attachments/assets/be395f2c-8c8b-47d7-8bbe-e01dc4c41c97)



closes #329