### PR TITLE
Show last character of ssh public key

### DIFF
--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -140,7 +140,7 @@ export function Profile() {
         useFlexGap={true}
       >
         <Typography variant={"body2"} sx={{ fontFamily: "monospace" }}>
-          {"..." + rawKey.substring(rawKey.length - 20, rawKey.length - 1)}
+          {"..." + rawKey.substring(rawKey.length - 20, rawKey.length)}
         </Typography>
         <CopyButton content={key} />
       </Stack>


### PR DESCRIPTION
I noticed that the ssh public keys that were being shown were missing their last character, this was due to the `substring()` method on strings in `js` using the end index parameter as up to but not including. So i removed the `-1` from the length so the last char is visible too.