### PR TITLE
Added optional query parameter for "all" on gpuLeases + used it when fetching all gpuLeases on the admin panel

### DIFF
--- a/src/api/deploy/gpuLeases.ts
+++ b/src/api/deploy/gpuLeases.ts
@@ -3,7 +3,10 @@ import { Jwt, Uuid } from "../../types";
 
 export const listGpuLeases = async (token: Jwt, vmId?: Uuid, all?: boolean) => {
   const vmIdQuery = vmId ? `?vmId=${encodeURIComponent(vmId)}` : "";
-  const allQuery = all !== undefined ? ((vmIdQuery ? "&" : "?") + "all=" + (all !== false ? "true" : "false")) : ""
+  const allQuery =
+    all !== undefined
+      ? (vmIdQuery ? "&" : "?") + "all=" + (all !== false ? "true" : "false")
+      : "";
   const url = `${import.meta.env.VITE_DEPLOY_API_URL}/gpuLeases${vmIdQuery + allQuery}`;
   const response = await fetch(url, {
     method: "GET",

--- a/src/api/deploy/gpuLeases.ts
+++ b/src/api/deploy/gpuLeases.ts
@@ -1,9 +1,10 @@
 import { GpuLeaseCreate } from "@kthcloud/go-deploy-types/types/v2/body";
 import { Jwt, Uuid } from "../../types";
 
-export const listGpuLeases = async (token: Jwt, vmId?: Uuid) => {
+export const listGpuLeases = async (token: Jwt, vmId?: Uuid, all?: boolean) => {
   const vmIdQuery = vmId ? `?vmId=${encodeURIComponent(vmId)}` : "";
-  const url = `${import.meta.env.VITE_DEPLOY_API_URL}/gpuLeases${vmIdQuery}`;
+  const allQuery = all !== undefined ? ((vmIdQuery ? "&" : "?") + "all=" + (all !== false ? "true" : "false")) : ""
+  const url = `${import.meta.env.VITE_DEPLOY_API_URL}/gpuLeases${vmIdQuery + allQuery}`;
   const response = await fetch(url, {
     method: "GET",
     headers: {

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -118,7 +118,11 @@ export const Admin = () => {
       },
       async () => {
         try {
-          const response = await listGpuLeases(keycloak.token!, undefined, true);
+          const response = await listGpuLeases(
+            keycloak.token!,
+            undefined,
+            true
+          );
           setDbGPUs(response);
         } catch (error: any) {
           errorHandler(error).forEach((e) =>

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -118,7 +118,7 @@ export const Admin = () => {
       },
       async () => {
         try {
-          const response = await listGpuLeases(keycloak.token!);
+          const response = await listGpuLeases(keycloak.token!, undefined, true);
           setDbGPUs(response);
         } catch (error: any) {
           errorHandler(error).forEach((e) =>


### PR DESCRIPTION
Added optional query parameter for "all" on gpuLeases to match the api endpoint.

The admin page will now show all gpuLeases and not only the ones belonging to the user fetching them.