### PR TITLE
Small bugfix: Impersonating deployment always showed them as custom

### DIFF
--- a/src/api/deploy/deployments.ts
+++ b/src/api/deploy/deployments.ts
@@ -9,7 +9,11 @@ export const getDeployment = async (token: string, id: string) => {
     },
   });
   const response = [await res.json()];
-  const result = response.map((obj) => ({ ...obj, type: "deployment" }));
+  const result = response.map((obj) => ({
+    ...obj,
+    deploymentType: obj.type,
+    type: "deployment",
+  }));
   if (Array.isArray(result)) return result;
   else throw new Error("Error getting deployments, response was not an array");
 };


### PR DESCRIPTION
This PR fixes an issue where the `deploymentType` attribute was not being added when fetching a deployment by ID. Causing impersonated deployments to incorrectly be displayed as custom deployments. The fix ensures that the `deploymentType` is properly included in the response, accurately reflecting the deployment type when impersonating.