### PR TITLE
small fix for docker-cli command if user is on windows, escape $ with ` instad of \

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,6 @@ VITE_KEYCLOAK_CLIENT_ID="landing"
 VITE_RANCHER_URL="https://mgmt.cloud.cbh.kth.se"
 VITE_DNS_URL="https://dns.cloud.cbh.kth.se"
 VITE_MAIA_URL="https://maia.app.cloud.cbh.kth.se/maia"
+# can be comma separated to add more
+VITE_SERVER_PLATFORM="linux/amd64"
 GENERATE_SOURCEMAP=false 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ ENV KEYCLOAK_CLIENT_ID="landing"
 ENV RANCHER_URL="https://mgmt.cloud.cbh.kth.se"
 ENV DNS_URL="https://dns.cloud.cbh.kth.se"
 ENV MAIA_URL="https://maia.app.cloud.cbh.kth.se/maia"
+# can be comma separated to add more
+ENV SERVER_PLATFORM="linux/amd64"
 
 EXPOSE 3000
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/pages/edit/deployments/GHActions.tsx
+++ b/src/pages/edit/deployments/GHActions.tsx
@@ -74,8 +74,7 @@ const GHActions = ({ resource }: { resource: Deployment }) => {
 
       const commands = [
         `docker login ${registry} -u ${username} -p ${password}`,
-        `docker build -t ${tag} .`,
-        `docker push ${tag}`,
+        `docker buildx build --platform="${import.meta.env.VITE_SERVER_PLATFORM || "linux/amd64"}" -t ${tag} --push .`,
       ];
 
       // escape $ for bash


### PR DESCRIPTION
Added tabs to the `docker cli` push command card, for MacOS/Linux and Windows. It should auomatically select based on the users os, but it is possible to change manually by clicking another tab too.

![image](https://github.com/user-attachments/assets/08cbd2be-63c0-4bbd-9f7a-e0793339b513)
![image](https://github.com/user-attachments/assets/166ea07f-598f-4d6d-9901-2b5fb4bb782e)

The difference is how bash and poweshell handles escaping the `$`, bash uses `\` while powershell uses `.

Another issue now that I came to think about it is that users with Apple silicon macs will produce arm64 images which wont work on the amd64 of the servers, so I made it so that it uses buildx with the target platform specified to the architecture supported by the servers, if kthcloud some day supports arm64 too It can be appended to the `SERVER_PLATFORM` environment variable like this `linux/amd64,linux/arm64`.