### PR TITLE
fix: use react router Link component on admin page menuitem in dropdown menu

### DIFF
--- a/src/layouts/dashboard/Menu.tsx
+++ b/src/layouts/dashboard/Menu.tsx
@@ -230,7 +230,11 @@ export default function Menu() {
             </Box>
 
             <Stack sx={{ p: 1 }}>
-              <MenuItem href={"/admin"} component={Link} onClick={handleClose}>
+              <MenuItem
+                to={"/admin"}
+                component={RouterLink}
+                onClick={handleClose}
+              >
                 {t("menu-admin-panel")}
               </MenuItem>
               <MenuItem


### PR DESCRIPTION
Use react-router Link component when navigating to the admin page from the dropdown menu so it doesn't refresh the entire SPA on click.